### PR TITLE
Fix event query order

### DIFF
--- a/app/Http/Controllers/BuatEventController.php
+++ b/app/Http/Controllers/BuatEventController.php
@@ -170,7 +170,7 @@ class BuatEventController extends Controller
     {
         $event = BuatEvent::where('id', $id)->first();
         $sponsor = Sponsor::where('event_id', $event->id)->get();
-        $eventexcept = BuatEvent::where('id', '!=', $event->id)->get()->take(5);
+        $eventexcept = BuatEvent::where('id', '!=', $event->id)->take(5)->get();
         $eventexcept = $eventexcept->shuffle();
         return view('page.admin.event.show', compact('event', 'eventexcept', 'sponsor'));
     }

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -135,7 +135,7 @@ class EventController extends Controller
     public function show($id)
     {
         $event = BuatEvent::where('id', $id)->first();
-        $eventexcept = BuatEvent::where('id', '!=', $event->id)->get()->take(5);
+        $eventexcept = BuatEvent::where('id', '!=', $event->id)->take(5)->get();
         $sponsor = Sponsor::where('event_id', $event->id)->get();
 
         $eventexcept = $eventexcept->shuffle();


### PR DESCRIPTION
## Summary
- update event and buat event show logic to run take before get

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b6c1eea10832696657a11bb119b8f